### PR TITLE
Addressing ReverseTabnabbing with info links

### DIFF
--- a/fargate/src/main/resources/META-INF/resources/index.html
+++ b/fargate/src/main/resources/META-INF/resources/index.html
@@ -140,9 +140,9 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li>Setup your IDE (https://quarkus.io/guides/maven-tooling.html)</li>
-                <li>Getting started (https://quarkus.io/guides/getting-started.html)</li>
-                <li>Quarkus Web Site (https://quarkus.io)</li>
+                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank" rel=“noopener noreferrer”>Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank" rel=“noopener noreferrer”>Getting started</a></li>
+                <li><a href="https://quarkus.io" target="_blank" rel=“noopener noreferrer”>Quarkus Web Site</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
*Issue #, if available:*
Security issue identifying target="_blank" as a source for potential ReverseTabnabbing

*Description of changes:*

Adding noopener, it ensures that the linked page does not have access to window.opener from the source page. While noreferrer makes sure that the request referer header is not sent along with the request. This way, the destination site does not see the originating URL that the user is coming from. The destination can not then manipulate original page to show phishing content.

https://www.comparitech.com/blog/information-security/reverse-tabnabbing/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
