### PR TITLE
Fix SSL Path

### DIFF
--- a/lambda/src/main/config/bootstrap
+++ b/lambda/src/main/config/bootstrap
@@ -2,4 +2,4 @@
 
 # wrapper bootstrap script for lambda custom runtime and quarkus
 
-./runner -Djava.library.path=./ -Djavax.net.ssl.trustStore=./cacerts
+./runner -Djava.library.path=./ -Djavax.net.ssl.trustStore=./ssl/cacerts


### PR DESCRIPTION
When deploying the Lambda code from scratch, I faced the following exception:

```
Exception in thread "Lambda Thread (NORMAL)" com.oracle.svm.core.jdk.UnsupportedFeatureError: Inaccessible trust store: ./cacerts See https://www.graalvm.org/reference-manual/native-image/CertificateManagement#runtime-options for more details about runtime certificate management.
```

When looking into the assembly/zip.xml, it references the cacert and store it in the ssl folder. To fix this issue, I updated the bootstrap script, to point to the correct trust store.